### PR TITLE
Allow ARN of task role to be passed in

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,5 @@
 resource "aws_ecs_task_definition" "taskdef" {
-    family = "${var.family}"
+    family                = "${var.family}"
     container_definitions = "[${join(",", var.container_definitions)}]"
+    task_role_arn         = "${var.task_role_arn}"
 }

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -10,10 +10,17 @@ provider "aws" {
   region                      = "eu-west-1"
 }
 
+variable "task_role_arn_param" {
+    description = "Allow the test to pass this in"
+    type = "string"
+    default = ""
+}
+
 module "taskdef" {
   source = "../.."
 
   family = "tf_ecs_taskdef_test_family"
+  task_role_arn = "${var.task_role_arn_param}"
   container_definitions = [
     <<END
 {

--- a/test/test_taskdef.py
+++ b/test/test_taskdef.py
@@ -12,7 +12,6 @@ class TestCreateTaskdef(unittest.TestCase):
     def setUp(self):
         check_call([ 'terraform', 'get', 'test/infra' ])
 
-    
     def test_create_taskdef(self):
         output = check_output([
             'terraform',
@@ -28,5 +27,25 @@ class TestCreateTaskdef(unittest.TestCase):
                 family:                "tf_ecs_taskdef_test_family"
                 network_mode:          "<computed>"
                 revision:              "<computed>"
+            Plan: 1 to add, 0 to change, 0 to destroy.
+        """).strip() in output
+
+    def test_task_role_arn_is_included(self):
+        output = check_output([
+            'terraform',
+            'plan',
+            '-var', 'task_role_arn_param=arn::iam:123',
+            '-no-color',
+            'test/infra'
+        ]).decode('utf-8')
+
+        assert dedent("""
+            + module.taskdef.aws_ecs_task_definition.taskdef
+                arn:                   "<computed>"
+                container_definitions: "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
+                family:                "tf_ecs_taskdef_test_family"
+                network_mode:          "<computed>"
+                revision:              "<computed>"
+                task_role_arn:         "arn::iam:123"
             Plan: 1 to add, 0 to change, 0 to destroy.
         """).strip() in output

--- a/variables.tf
+++ b/variables.tf
@@ -7,3 +7,9 @@ variable "container_definitions" {
     description = "A list of valid container definitions provided as a single valid JSON document."
     type = "list"
 }
+
+variable "task_role_arn" {
+    description = "The Amazon Resource Name for an IAM role for the task"
+    type = "string"
+    default = ""
+}


### PR DESCRIPTION
We'd like to be able to use this module within another that creates a task role so this should optionally take a role ARN parameter.

JIRA: PLAT-931