### PR TITLE
[PLAT-71] Allow define one optional volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This module creates a basic ECS Task Definition.
 * `family` - the name of the task definition. For ECS services it is recommended to use the same name as for the service, and for that name to consist of the environment name (e.g. "live"), the comonent name (e.g. "foobar-service"), and an optional suffix (if an environment has multiple services for the component running - e.g. in a multi-tenant setup), separated by hyphens.
 * `container_definitions` - list of strings. Each string should be a JSON document describing a single container definition - see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html.
 * `task_role_arn` - The Amazon Resource Name for an IAM role for the task.
+* `volume` - Volume block map with 'name' and 'host_path'. 'name': The name of the volume as is referenced in the sourceVolume. 'host_path' The path on the host container instance that is presented to the container.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module creates a basic ECS Task Definition.
 
     module "taskdef" {
         source = "github.com/mergermarket/tf_ecs_task_definition"
-        
+
         family = "live-service-name"
         container_definitions = [
             <<END
@@ -23,6 +23,7 @@ This module creates a basic ECS Task Definition.
 
 * `family` - the name of the task definition. For ECS services it is recommended to use the same name as for the service, and for that name to consist of the environment name (e.g. "live"), the comonent name (e.g. "foobar-service"), and an optional suffix (if an environment has multiple services for the component running - e.g. in a multi-tenant setup), separated by hyphens.
 * `container_definitions` - list of strings. Each string should be a JSON document describing a single container definition - see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html.
+* `task_role_arn` - The Amazon Resource Name for an IAM role for the task.
 
 ### Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -2,4 +2,22 @@ resource "aws_ecs_task_definition" "taskdef" {
     family                = "${var.family}"
     container_definitions = "[${join(",", var.container_definitions)}]"
     task_role_arn         = "${var.task_role_arn}"
+
+    volume = {
+        name      = "${lookup(var.volume, "name", "dummy")}",
+        host_path = "${lookup(var.volume, "host_path", "/tmp/dummy_volume")}"
+    }
+}
+
+variable volumes {
+    default = [
+        {
+            "name"= "aaa",
+            "host_path"= "/tmp"
+        }
+    ]
+}
+
+output volumes {
+    value = "${var.volumes}"
 }

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -16,11 +16,18 @@ variable "task_role_arn_param" {
     default = ""
 }
 
+variable "task_volume_param" {
+    description = "Allow the test to pass this in"
+    type = "map"
+    default = {}
+}
+
 module "taskdef" {
   source = "../.."
 
   family = "tf_ecs_taskdef_test_family"
   task_role_arn = "${var.task_role_arn_param}"
+  volume = "${var.task_volume_param}"
   container_definitions = [
     <<END
 {

--- a/test/test_taskdef.py
+++ b/test/test_taskdef.py
@@ -19,14 +19,18 @@ class TestCreateTaskdef(unittest.TestCase):
             '-no-color',
             'test/infra'
         ]).decode('utf-8')
+        print(output)
 
         assert dedent("""
             + module.taskdef.aws_ecs_task_definition.taskdef
-                arn:                   "<computed>"
-                container_definitions: "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
-                family:                "tf_ecs_taskdef_test_family"
-                network_mode:          "<computed>"
-                revision:              "<computed>"
+                arn:                         "<computed>"
+                container_definitions:       "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
+                family:                      "tf_ecs_taskdef_test_family"
+                network_mode:                "<computed>"
+                revision:                    "<computed>"
+                volume.#:                    "1"
+                volume.3039886685.host_path: "/tmp/dummy_volume"
+                volume.3039886685.name:      "dummy"
             Plan: 1 to add, 0 to change, 0 to destroy.
         """).strip() in output
 
@@ -41,11 +45,38 @@ class TestCreateTaskdef(unittest.TestCase):
 
         assert dedent("""
             + module.taskdef.aws_ecs_task_definition.taskdef
-                arn:                   "<computed>"
-                container_definitions: "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
-                family:                "tf_ecs_taskdef_test_family"
-                network_mode:          "<computed>"
-                revision:              "<computed>"
-                task_role_arn:         "arn::iam:123"
+                arn:                         "<computed>"
+                container_definitions:       "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
+                family:                      "tf_ecs_taskdef_test_family"
+                network_mode:                "<computed>"
+                revision:                    "<computed>"
+                task_role_arn:               "arn::iam:123"
+                volume.#:                    "1"
+                volume.3039886685.host_path: "/tmp/dummy_volume"
+                volume.3039886685.name:      "dummy"
+            Plan: 1 to add, 0 to change, 0 to destroy.
+        """).strip() in output
+
+    def test_task_volume_is_included(self):
+        output = check_output([
+            'terraform',
+            'plan',
+            '-var', 'task_volume_param={name="data_volume",host_path="/mnt/data"}',
+            '-no-color',
+            'test/infra'
+        ]).decode('utf-8')
+
+        print(output)
+
+        assert dedent("""
+            + module.taskdef.aws_ecs_task_definition.taskdef
+                arn:                       "<computed>"
+                container_definitions:     "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
+                family:                    "tf_ecs_taskdef_test_family"
+                network_mode:              "<computed>"
+                revision:                  "<computed>"
+                volume.#:                  "1"
+                volume.27251535.host_path: "/mnt/data"
+                volume.27251535.name:      "data_volume"
             Plan: 1 to add, 0 to change, 0 to destroy.
         """).strip() in output

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,9 @@ variable "task_role_arn" {
     type = "string"
     default = ""
 }
+
+variable "volume" {
+    description = "Volume block map with 'name' and 'host_path'. 'name': The name of the volume as is referenced in the sourceVolume. 'host_path' The path on the host container instance that is presented to the container."
+    type = "map"
+    default = {}
+}


### PR DESCRIPTION
For some cases and workloads we need to pass some modules to the task definition. The volumes are passed as a list of maps to the `ecs_task_resource`[1].

But the current syntax of terraform does not allow consume this value directly from a variable. Trying to do so, we hit the issues described in [2] and [3] (pending to report a specific bug).

But we found out that it works if we build the map structure directly within the resource, and we use interpolation to consume the values of the map.

Meanwhile the terraform project does not provide a definitive solution, we
will implement the following workaround:

 - The module will receive configuration for one unique module, being the default a empty map {}
 - If the map is empty, a dummy volume will be passed as `name=dummy` and `host_path=/tmp/dummy_volume`

This would cover our specific case in the short term, and can be later easily adapted to use a optional list of volumes.

[1] https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume
[2] https://github.com/hashicorp/terraform/issues/10407
[3] https://github.com/hashicorp/terraform/issues/7705#issuecomment-300564571