### PR TITLE
[PLAT-71] Allow define one optional volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This module creates a basic ECS Task Definition.
 * `family` - the name of the task definition. For ECS services it is recommended to use the same name as for the service, and for that name to consist of the environment name (e.g. "live"), the comonent name (e.g. "foobar-service"), and an optional suffix (if an environment has multiple services for the component running - e.g. in a multi-tenant setup), separated by hyphens.
 * `container_definitions` - list of strings. Each string should be a JSON document describing a single container definition - see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html.
 * `task_role_arn` - The Amazon Resource Name for an IAM role for the task.
+* `volume` - Volume block map with 'name' and 'host_path'. 'name': The name of the volume as is referenced in the sourceVolume. 'host_path' The path on the host container instance that is presented to the container.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module creates a basic ECS Task Definition.
 
     module "taskdef" {
         source = "github.com/mergermarket/tf_ecs_task_definition"
-        
+
         family = "live-service-name"
         container_definitions = [
             <<END
@@ -23,6 +23,7 @@ This module creates a basic ECS Task Definition.
 
 * `family` - the name of the task definition. For ECS services it is recommended to use the same name as for the service, and for that name to consist of the environment name (e.g. "live"), the comonent name (e.g. "foobar-service"), and an optional suffix (if an environment has multiple services for the component running - e.g. in a multi-tenant setup), separated by hyphens.
 * `container_definitions` - list of strings. Each string should be a JSON document describing a single container definition - see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html.
+* `task_role_arn` - The Amazon Resource Name for an IAM role for the task.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ This module creates a basic ECS Task Definition.
     }
     END
         ]
+
+        volume = {
+            name = 'data'
+            host_path = '/mnt/data'
+        }
     }
 
 ## API
@@ -24,7 +29,7 @@ This module creates a basic ECS Task Definition.
 * `family` - the name of the task definition. For ECS services it is recommended to use the same name as for the service, and for that name to consist of the environment name (e.g. "live"), the comonent name (e.g. "foobar-service"), and an optional suffix (if an environment has multiple services for the component running - e.g. in a multi-tenant setup), separated by hyphens.
 * `container_definitions` - list of strings. Each string should be a JSON document describing a single container definition - see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html.
 * `task_role_arn` - The Amazon Resource Name for an IAM role for the task.
-* `volume` - Volume block map with 'name' and 'host_path'. 'name': The name of the volume as is referenced in the sourceVolume. 'host_path' The path on the host container instance that is presented to the container.
+* `volume` - Volume block map with 'name' and 'host_path'. See https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume for more info.
 
 ### Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 resource "aws_ecs_task_definition" "taskdef" {
-    family                = "${var.family}"
-    container_definitions = "[${join(",", var.container_definitions)}]"
-    task_role_arn         = "${var.task_role_arn}"
+  family                = "${var.family}"
+  container_definitions = "[${join(",", var.container_definitions)}]"
+  task_role_arn         = "${var.task_role_arn}"
 
-    volume = {
-        name      = "${lookup(var.volume, "name", "dummy")}",
-        host_path = "${lookup(var.volume, "host_path", "/tmp/dummy_volume")}"
-    }
+  volume = {
+    name      = "${lookup(var.volume, "name", "dummy")}"
+    host_path = "${lookup(var.volume, "host_path", "/tmp/dummy_volume")}"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -2,4 +2,9 @@ resource "aws_ecs_task_definition" "taskdef" {
     family                = "${var.family}"
     container_definitions = "[${join(",", var.container_definitions)}]"
     task_role_arn         = "${var.task_role_arn}"
+
+    volume = {
+        name      = "${lookup(var.volume, "name", "dummy")}",
+        host_path = "${lookup(var.volume, "host_path", "/tmp/dummy_volume")}"
+    }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "arn" {
-    value = "${aws_ecs_task_definition.taskdef.arn}"
+  value = "${aws_ecs_task_definition.taskdef.arn}"
 }

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -5,6 +5,8 @@ ENV TERRAFORM_VERSION=0.9.5
 ENV TERRAFORM_ZIP=terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 ENV TERRAFORM_SUM=0cbb5474c76d878fbc99e7705ce6117f4ea0838175c13b2663286a207e38d783
 
+ENV PYTHONDONTWRITEBYTECODE donot
+
 RUN apk add -U ca-certificates curl && \
     cd /tmp && \
     curl -fsSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_ZIP} && \

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -16,11 +16,18 @@ variable "task_role_arn_param" {
     default = ""
 }
 
+variable "task_volume_param" {
+    description = "Allow the test to pass this in"
+    type = "map"
+    default = {}
+}
+
 module "taskdef" {
   source = "../.."
 
   family = "tf_ecs_taskdef_test_family"
   task_role_arn = "${var.task_role_arn_param}"
+  volume = "${var.task_volume_param}"
   container_definitions = [
     <<END
 {

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -11,13 +11,13 @@ provider "aws" {
 }
 
 variable "task_role_arn_param" {
-    description = "Allow the test to pass this in"
+    description = "The test can set this var to be passed to the module"
     type = "string"
     default = ""
 }
 
 variable "task_volume_param" {
-    description = "Allow the test to pass this in"
+    description = "The test can set this var to be passed to the module"
     type = "map"
     default = {}
 }

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -11,23 +11,24 @@ provider "aws" {
 }
 
 variable "task_role_arn_param" {
-    description = "The test can set this var to be passed to the module"
-    type = "string"
-    default = ""
+  description = "The test can set this var to be passed to the module"
+  type        = "string"
+  default     = ""
 }
 
 variable "task_volume_param" {
-    description = "The test can set this var to be passed to the module"
-    type = "map"
-    default = {}
+  description = "The test can set this var to be passed to the module"
+  type        = "map"
+  default     = {}
 }
 
 module "taskdef" {
   source = "../.."
 
-  family = "tf_ecs_taskdef_test_family"
+  family        = "tf_ecs_taskdef_test_family"
   task_role_arn = "${var.task_role_arn_param}"
-  volume = "${var.task_volume_param}"
+  volume        = "${var.task_volume_param}"
+
   container_definitions = [
     <<END
 {
@@ -38,9 +39,10 @@ module "taskdef" {
   "essential": true
 }
 END
+    ,
   ]
 }
 
 output "taskdef_arn" {
-    value = "${module.taskdef.arn}"
+  value = "${module.taskdef.arn}"
 }

--- a/test/test_taskdef.py
+++ b/test/test_taskdef.py
@@ -19,14 +19,18 @@ class TestCreateTaskdef(unittest.TestCase):
             '-no-color',
             'test/infra'
         ]).decode('utf-8')
+        print(output)
 
         assert dedent("""
             + module.taskdef.aws_ecs_task_definition.taskdef
-                arn:                   "<computed>"
-                container_definitions: "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
-                family:                "tf_ecs_taskdef_test_family"
-                network_mode:          "<computed>"
-                revision:              "<computed>"
+                arn:                         "<computed>"
+                container_definitions:       "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
+                family:                      "tf_ecs_taskdef_test_family"
+                network_mode:                "<computed>"
+                revision:                    "<computed>"
+                volume.#:                    "1"
+                volume.3039886685.host_path: "/tmp/dummy_volume"
+                volume.3039886685.name:      "dummy"
             Plan: 1 to add, 0 to change, 0 to destroy.
         """).strip() in output
 
@@ -41,11 +45,38 @@ class TestCreateTaskdef(unittest.TestCase):
 
         assert dedent("""
             + module.taskdef.aws_ecs_task_definition.taskdef
-                arn:                   "<computed>"
-                container_definitions: "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
-                family:                "tf_ecs_taskdef_test_family"
-                network_mode:          "<computed>"
-                revision:              "<computed>"
-                task_role_arn:         "arn::iam:123"
+                arn:                         "<computed>"
+                container_definitions:       "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
+                family:                      "tf_ecs_taskdef_test_family"
+                network_mode:                "<computed>"
+                revision:                    "<computed>"
+                task_role_arn:               "arn::iam:123"
+                volume.#:                    "1"
+                volume.3039886685.host_path: "/tmp/dummy_volume"
+                volume.3039886685.name:      "dummy"
+            Plan: 1 to add, 0 to change, 0 to destroy.
+        """).strip() in output
+
+    def test_task_volume_is_included(self):
+        output = check_output([
+            'terraform',
+            'plan',
+            '-var', 'task_volume_param={name="data_volume",host_path="/mnt/data"}',
+            '-no-color',
+            'test/infra'
+        ]).decode('utf-8')
+
+        print(output)
+
+        assert dedent("""
+            + module.taskdef.aws_ecs_task_definition.taskdef
+                arn:                       "<computed>"
+                container_definitions:     "a173db30ec08bc3c9ca77b5797aeae40987c1ef7"
+                family:                    "tf_ecs_taskdef_test_family"
+                network_mode:              "<computed>"
+                revision:                  "<computed>"
+                volume.#:                  "1"
+                volume.27251535.host_path: "/mnt/data"
+                volume.27251535.name:      "data_volume"
             Plan: 1 to add, 0 to change, 0 to destroy.
         """).strip() in output

--- a/test/test_taskdef.py
+++ b/test/test_taskdef.py
@@ -1,10 +1,9 @@
-import unittest
 import os
-import tempfile
 import shutil
-
-from textwrap import dedent
+import tempfile
+import unittest
 from subprocess import check_call, check_output
+from textwrap import dedent
 
 
 class TestCreateTaskdef(unittest.TestCase):

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,9 @@ variable "task_role_arn" {
     type = "string"
     default = ""
 }
+
+variable "volume" {
+    description = "Volume block map with 'name' and 'host_path'. 'name': The name of the volume as is referenced in the sourceVolume. 'host_path' The path on the host container instance that is presented to the container."
+    type = "map"
+    default = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,21 +1,21 @@
 variable "family" {
-    description = "A unique name for your task defintion."
-    type = "string"
+  description = "A unique name for your task defintion."
+  type        = "string"
 }
 
 variable "container_definitions" {
-    description = "A list of valid container definitions provided as a single valid JSON document."
-    type = "list"
+  description = "A list of valid container definitions provided as a single valid JSON document."
+  type        = "list"
 }
 
 variable "task_role_arn" {
-    description = "The Amazon Resource Name for an IAM role for the task"
-    type = "string"
-    default = ""
+  description = "The Amazon Resource Name for an IAM role for the task"
+  type        = "string"
+  default     = ""
 }
 
 variable "volume" {
-    description = "Volume block map with 'name' and 'host_path'."
-    type = "map"
-    default = {}
+  description = "Volume block map with 'name' and 'host_path'."
+  type        = "map"
+  default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "task_role_arn" {
 }
 
 variable "volume" {
-    description = "Volume block map with 'name' and 'host_path'. 'name': The name of the volume as is referenced in the sourceVolume. 'host_path' The path on the host container instance that is presented to the container."
+    description = "Volume block map with 'name' and 'host_path'."
     type = "map"
     default = {}
 }


### PR DESCRIPTION
> Note: same as https://github.com/mergermarket/tf_ecs_task_definition/pull/2 fixing spurious content

For some cases and workloads we need to pass some modules to the task definition. The volumes are passed as a list of maps to the `ecs_task_resource`[1].

But the current syntax of terraform does not allow consume this value directly from a variable. Trying to do so, we hit the issues described in [2] and [3] (pending to report a specific bug).

But we found out that it works if we build the map structure directly within the resource, and we use interpolation to consume the values of the map.

Meanwhile the terraform project does not provide a definitive solution, we
will implement the following workaround:

 - The module will receive configuration for one unique module, being the default a empty map {}
 - If the map is empty, a dummy volume will be passed as `name=dummy` and `host_path=/tmp/dummy_volume`

This would cover our specific case in the short term, and can be later easily adapted to use a optional list of volumes.

[1] https://www.terraform.io/docs/providers/aws/r/ecs_task_definition.html#volume
[2] https://github.com/hashicorp/terraform/issues/10407
[3] https://github.com/hashicorp/terraform/issues/7705#issuecomment-300564571